### PR TITLE
Bind the Day, Month, and Year values in RspGdsDateInputTagHelper

### DIFF
--- a/src/Rsp.Gds.Component/TagHelpers/Base/RspGdsDateInputTagHelper.cs
+++ b/src/Rsp.Gds.Component/TagHelpers/Base/RspGdsDateInputTagHelper.cs
@@ -24,6 +24,12 @@ public class RspGdsDateInputTagHelper : TagHelper
     public string DayName { get; set; }
 
     /// <summary>
+    ///     Gets or sets the pre-filled value for the "Day" input field.
+    /// </summary>
+    [HtmlAttributeName("day-value")]
+    public string? DayValue { get; set; }
+
+    /// <summary>
     ///     The name attribute for the "Month" input field.
     ///     Also used as the input's HTML id.
     /// </summary>
@@ -31,11 +37,23 @@ public class RspGdsDateInputTagHelper : TagHelper
     public string MonthName { get; set; }
 
     /// <summary>
+    ///     Gets or sets the pre-filled value for the "Month" input field.
+    /// </summary>
+    [HtmlAttributeName("month-value")]
+    public string? MonthValue { get; set; }
+
+    /// <summary>
     ///     The name attribute for the "Year" input field.
     ///     Also used as the input's HTML id.
     /// </summary>
     [HtmlAttributeName("year-name")]
     public string YearName { get; set; }
+
+    /// <summary>
+    ///     Gets or sets the pre-filled value for the "Year" input field.
+    /// </summary>
+    [HtmlAttributeName("year-value")]
+    public string? YearValue { get; set; }
 
     /// <summary>
     ///     The label text to be displayed above the date input.
@@ -96,7 +114,6 @@ public class RspGdsDateInputTagHelper : TagHelper
     /// </summary>
     [HtmlAttributeName("validation-message")]
     public string ValidationMessage { get; set; }
-
 
     /// <summary>
     ///     Provides access to the current view context, including ModelState for validation.
@@ -167,7 +184,8 @@ public class RspGdsDateInputTagHelper : TagHelper
                        id='{DayName}'
                        name='{DayName}'
                        type='text'
-                       inputmode='numeric' />
+                       inputmode='numeric'
+                       value='{HtmlEncoder.Default.Encode(DayValue ?? "")}' />
             </div>
         </div>";
 
@@ -180,7 +198,8 @@ public class RspGdsDateInputTagHelper : TagHelper
                        id='{MonthName}'
                        name='{MonthName}'
                        type='text'
-                       inputmode='numeric' />
+                       inputmode='numeric'
+                       value='{HtmlEncoder.Default.Encode(MonthValue ?? "")}' />
             </div>
         </div>";
 
@@ -193,7 +212,8 @@ public class RspGdsDateInputTagHelper : TagHelper
                        id='{YearName}'
                        name='{YearName}'
                        type='text'
-                       inputmode='numeric' />
+                       inputmode='numeric'
+                       value='{HtmlEncoder.Default.Encode(YearValue ?? "")}' />
             </div>
         </div>";
 


### PR DESCRIPTION
## What was the purpose of this ticket?
Bind the Day, Month, and Year values in RspGdsDateInputTagHelper

## Jira Ref
[RSP-3867](https://nihr.atlassian.net/browse/RSP-3867)

## Type of Change

Put [X] inside the [] to make the box ticked

- [] New feature
- [] Refactoring
- [x] Bug-fix
- [] DevOps
- [] Testing

## Solution

What work was completed to cover off the story?

- List out changes made to the repo

## Checklist

- [ ] Your code builds clean without any  warnings
- [ ] You have added unit tests
- [ ] All the added unit tests add value i.e. assert the right thing?
- [ ] You are using the correct naming conventions
- [ ] You have fixed all the suggestions made by .editorconfig and/or Roslynator
- [ ] There are no dead code and no "TODO" comments left
- [ ] Please make sure that using statements are sorted with using System* statements at the top. You can use CTRL + K, CTRL + D command to format the file, that will respect the .editorconfig, or use the Visual Studio extension called [CodeMaid](http://www.codemaid.net/) to do that for you automatically on save.